### PR TITLE
Fix: 404 refresh bug on deployment

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,9 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
   // should be using with custom backend but bug in next:
   // https://github.com/vercel/next.js/issues/2682
   // useFileSystemPublicRoutes: false
+  trailingSlash: true
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Added `trailingSlash` option to `next.config.js` in hopes to fix the bug where the page 404s when refreshing on the deployment.